### PR TITLE
Crossover Support

### DIFF
--- a/software/CMakeLists.txt
+++ b/software/CMakeLists.txt
@@ -110,6 +110,9 @@ set(COMMON_SOURCES
   src/models/model.h
   src/models/pl_nn_model.cpp
   src/models/pl_nn_model.h
+  src/optimizers/crossover_funs.h
+  src/optimizers/crossover_types.cpp
+  src/optimizers/crossover_types.h
   src/optimizers/ga_funs.cpp
   src/optimizers/ga_funs.h
   src/optimizers/ga.cpp

--- a/software/src/main.cpp
+++ b/software/src/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  train(map_file);
+  train_crossover_example(map_file);
 
   // // load map
   // jnb::TileMap map;

--- a/software/src/models/mlp_map_lut.h
+++ b/software/src/models/mlp_map_lut.h
@@ -48,6 +48,12 @@ struct TileEmbeddings {
       val += dist(rng);
     }
   }
+
+  std::vector<ParamSpan> get_spans() {
+    std::vector<ParamSpan> spans;
+    spans.push_back(std::span<float>(data.data(), data.size()));
+    return spans;
+  }
 };
 
 class SimpleModelTileEmb : public Model<obs::TileCoords> {
@@ -75,6 +81,21 @@ public:
   }
   std::string get_name() const override {
     return "SimpleModelTileEmb";
+  }
+  std::vector<ParamSpan> get_spans() override {
+    std::vector<ParamSpan> spans;
+    auto base_model_spans = base_model->get_spans();
+    spans.insert(spans.end(), base_model_spans.begin(), base_model_spans.end());
+    for (auto &embedding : embeddings) {
+      auto embedding_spans = embedding.get_spans();
+      spans.insert(spans.end(), embedding_spans.begin(), embedding_spans.end());
+    }
+    return spans;
+  }
+
+  void apply_spans() override {
+    // tile embeddings don't need to be constrained, but base_model might
+    base_model->apply_spans();
   }
 
 private:

--- a/software/src/models/mlp_simple.cpp
+++ b/software/src/models/mlp_simple.cpp
@@ -10,4 +10,8 @@ void SimpleMLP::mutate(std::mt19937 &rng, float mutation_rate) {
   net.mutate(rng, mutation_rate);
 }
 
+std::vector<ParamSpan> SimpleMLP::get_spans() {
+  return net.get_spans();
+}
+
 } // namespace model

--- a/software/src/models/mlp_simple.h
+++ b/software/src/models/mlp_simple.h
@@ -27,6 +27,7 @@ public:
   std::string get_name() const override {
     return "SimpleMLP";
   }
+  std::vector<ParamSpan> get_spans() override;
 
 private:
   size_t hidden_size;

--- a/software/src/models/model.h
+++ b/software/src/models/model.h
@@ -1,10 +1,17 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <random>
+#include <span>
 #include <string>
+#include <variant>
+#include <vector>
 
 namespace model {
+
+// Covers all the possible parameter types that models use. Add more as needed.
+using ParamSpan = std::variant<std::span<float>, std::span<int8_t>>;
 
 template <typename ObsType>
 class Model {
@@ -23,6 +30,10 @@ public:
   virtual void forward(const ObsType &observation, std::vector<float> &action) {}
   virtual std::shared_ptr<Model<ObsType>> clone() const = 0;
   virtual std::string get_name() const = 0;
+  virtual std::vector<ParamSpan> get_spans() {
+    return {};
+  };
+  virtual void apply_spans() {};
 };
 
 } // namespace model

--- a/software/src/models/model.h
+++ b/software/src/models/model.h
@@ -13,6 +13,14 @@ namespace model {
 // Covers all the possible parameter types that models use. Add more as needed.
 using ParamSpan = std::variant<std::span<float>, std::span<int8_t>>;
 
+// TODO: Might be able to have a CoreModel that has everything but the
+// template stuff, then have Model extend CoreModel and add the template stuff.
+// that way, stuff that doesn't need the templated functions can just take in
+// a CoreModel instead of the complicated Model<ObsType> type. an example of
+// a beneficiary is the crossover functions, which at the highest level
+// take in two solutions and spit out a model, where all three are templated.
+// these functions only care about getting the spans of the models, which
+// doesn't require templates. 
 template <typename ObsType>
 class Model {
 public:

--- a/software/src/models/pl_nn_model.h
+++ b/software/src/models/pl_nn_model.h
@@ -1,3 +1,6 @@
+// this model was backported from our pl implementation for debugging purposes.
+// it should no longer be used. TODO: remove this and make the quinary nn generic enough
+// to fully replace this.
 #pragma once
 
 #include <cassert>

--- a/software/src/neural_net.h
+++ b/software/src/neural_net.h
@@ -3,6 +3,8 @@
 #include <random>
 #include <vector>
 
+#include "model.h"
+
 namespace model {
 
 // a staticly allocated neural network with a generic parameter type
@@ -169,6 +171,13 @@ struct DynamicLayer {
       bias[i] += dist(rng);
     }
   }
+
+  std::vector<ParamSpan> get_spans() {
+    std::vector<ParamSpan> spans;
+    spans.push_back(std::span<T>(weights.data(), weights.size()));
+    spans.push_back(std::span<T>(bias.data(), bias.size()));
+    return spans;
+  }
 };
 
 template <typename T>
@@ -223,6 +232,15 @@ struct DynamicNeuralNet {
       }
     }
     return shape;
+  }
+
+  std::vector<ParamSpan> get_spans() {
+    std::vector<ParamSpan> spans;
+    for (auto &layer : layers) {
+      auto layer_spans = layer.get_spans();
+      spans.insert(spans.end(), layer_spans.begin(), layer_spans.end());
+    }
+    return spans;
   }
 };
 

--- a/software/src/optimizers/crossover_funs.h
+++ b/software/src/optimizers/crossover_funs.h
@@ -1,10 +1,34 @@
 #pragma once
 
+#include <random>
+
 #include "crossover_types.h"
 
 namespace ga {
 
-// define some simple crossover functions
+// parameter level crossover functions
 
+// auto uniform_crossover(auto param1, auto param2, float sol1_relative_perf, std::mt19937 &rng) {
+//   std::bernoulli_distribution d(0.5f);
+//   return d(rng) ? param1 : param2;
+// }
+
+// auto uniform_weighted_crossover(auto param1, auto param2, float sol1_relative_perf, std::mt19937
+// &rng) {
+//   std::bernoulli_distribution d(sol1_relative_perf);
+//   return d(rng) ? param1 : param2;
+// }
+
+// not sure why, but it seems like these have to be defined as lambdas
+
+auto uniform_crossover = [](auto p1, auto p2, float sol1_relative_perf, std::mt19937 &rng) {
+  std::bernoulli_distribution d(0.5f);
+  return d(rng) ? p1 : p2;
+};
+
+auto uniform_weighted_crossover = [](auto p1, auto p2, float sol1_relative_perf, std::mt19937 &rng) {
+  std::bernoulli_distribution d(sol1_relative_perf);
+  return d(rng) ? p1 : p2;
+};
 
 } // namespace ga

--- a/software/src/optimizers/crossover_funs.h
+++ b/software/src/optimizers/crossover_funs.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "crossover_types.h"
+
+namespace ga {
+
+// define some simple crossover functions
+
+
+} // namespace ga

--- a/software/src/optimizers/crossover_types.cpp
+++ b/software/src/optimizers/crossover_types.cpp
@@ -1,0 +1,50 @@
+#include "crossover_types.h"
+
+using model::ParamSpan;
+
+namespace ga {
+
+bool check_spans_compatible(const std::vector<ParamSpan> &spans1,
+                            const std::vector<ParamSpan> &spans2) {
+  // check if number of spans is equal
+  if (spans1.size() != spans2.size()) {
+    return false;
+  }
+
+  // check compatibility of each span
+  // TODO: use C++23 and use https://en.cppreference.com/w/cpp/ranges/zip_view
+  for (size_t i = 0; i < spans1.size(); ++i) {
+    const ParamSpan &span1 = spans1[i];
+    const ParamSpan &span2 = spans2[i];
+
+    // check type compatibility
+    if (span1.index() != span2.index()) {
+      return false;
+    }
+
+    // check length compatibility
+    bool same_size =
+        std::visit([](const auto &s1, const auto &s2) -> bool { return s1.size() == s2.size(); },
+                   span1, span2);
+
+    if (!same_size) {
+      return false;
+    }
+  }
+
+  // everything above matched, so they are compatible.
+  return true;
+}
+
+VectorCrossover to_vec_crossover(SpanCrossover span_cross) {
+  return [span_cross](const std::vector<ParamSpan> &spans1, const std::vector<ParamSpan> &spans2,
+                      std::vector<ParamSpan> &child_spans, float sol1_relative_perf,
+                      std::mt19937 &rng) {
+    // apply the span crossover to each span pair
+    for (size_t i = 0; i < spans1.size(); ++i) {
+      span_cross(spans1[i], spans2[i], child_spans[i], sol1_relative_perf, rng);
+    }
+  };
+}
+
+} // namespace ga

--- a/software/src/optimizers/crossover_types.h
+++ b/software/src/optimizers/crossover_types.h
@@ -28,6 +28,9 @@ template <typename T>
 using ParamCrossover =
     std::function<T(T param1, T param2, float sol1_relative_perf, std::mt19937 &rng)>;
 
+bool check_spans_compatible(const std::vector<ParamSpan> &spans1,
+                            const std::vector<ParamSpan> &spans2);
+
 // helper that turns a VectorCrossover into a SolCrossover
 template <typename ObsType>
 SolCrossover<ObsType> to_sol_crossover(VectorCrossover vec_cross) {
@@ -46,7 +49,10 @@ SolCrossover<ObsType> to_sol_crossover(VectorCrossover vec_cross) {
     // parents are compatible so move on to the crossover
     auto child = sol1.model->clone();
     float sol1_relative_perf = static_cast<float>(sol1.fitness) / (sol1.fitness + sol2.fitness);
-    vec_cross(sol1.model->get_spans(), sol2.model->get_spans(), child->get_spans(),
+    auto s1_spans = sol1.model->get_spans();
+    auto s2_spans = sol2.model->get_spans();
+    auto c_spans = child->get_spans();
+    vec_cross(s1_spans, s2_spans, c_spans,
               sol1_relative_perf, rng);
     // apply child crossover
     child->apply_spans();
@@ -55,16 +61,7 @@ SolCrossover<ObsType> to_sol_crossover(VectorCrossover vec_cross) {
 }
 
 // helper that turns a SpanCrossover into a VectorCrossover
-VectorCrossover to_vec_crossover(SpanCrossover span_cross) {
-  return [span_cross](const std::vector<ParamSpan> &spans1, const std::vector<ParamSpan> &spans2,
-                      std::vector<ParamSpan> &child_spans, float sol1_relative_perf,
-                      std::mt19937 &rng) {
-    // apply the span crossover to each span pair
-    for (size_t i = 0; i < spans1.size(); ++i) {
-      span_cross(spans1[i], spans2[i], child_spans[i], sol1_relative_perf, rng);
-    }
-  };
-}
+VectorCrossover to_vec_crossover(SpanCrossover span_cross);
 
 // helper that turns a ParamCrossover into a SpanCrossover
 template <typename F>
@@ -82,39 +79,6 @@ SpanCrossover to_span_crossover(F param_cross) {
         },
         span1, span2, child_span);
   };
-}
-
-template <typename ObsType>
-bool check_spans_compatible(const std::vector<ParamSpan> &spans1,
-                            const std::vector<ParamSpan> &spans2) {
-  // check if number of spans is equal
-  if (spans1.size() != spans2.size()) {
-    return false;
-  }
-
-  // check compatibility of each span
-  // TODO: use C++23 and use https://en.cppreference.com/w/cpp/ranges/zip_view
-  for (size_t i = 0; i < spans1.size(); ++i) {
-    const ParamSpan &span1 = spans1[i];
-    const ParamSpan &span2 = spans2[i];
-
-    // check type compatibility
-    if (span1.index() != span2.index()) {
-      return false;
-    }
-
-    // check length compatibility
-    bool same_size =
-        std::visit([](const auto &s1, const auto &s2) -> bool { return s1.size() == s2.size(); },
-                   span1, span2);
-
-    if (!same_size) {
-      return false;
-    }
-  }
-
-  // everything above matched, so they are compatible.
-  return true;
 }
 
 } // namespace ga

--- a/software/src/optimizers/crossover_types.h
+++ b/software/src/optimizers/crossover_types.h
@@ -1,0 +1,120 @@
+// defines types for crossover functions
+#pragma once
+
+#include "ga.h"
+
+namespace ga {
+
+// file-private declarations
+namespace {
+using model::ParamSpan;
+}
+
+// type aliases for crossover functions
+template <typename ObsType>
+using SolCrossover = std::function<std::shared_ptr<Model<ObsType>>(
+    const Solution<ObsType> &sol1, const Solution<ObsType> &sol2, std::mt19937 &rng)>;
+
+// note: sol1_relative_perf = (fit1 / (fit1 + fit2))
+using VectorCrossover =
+    std::function<void(const std::vector<ParamSpan> &spans1, const std::vector<ParamSpan> &spans2,
+                       std::vector<ParamSpan> &child, float sol1_relative_perf, std::mt19937 &rng)>;
+
+using SpanCrossover =
+    std::function<void(const ParamSpan &span1, const ParamSpan &span2, ParamSpan &child,
+                       float sol1_relative_perf, std::mt19937 &rng)>;
+
+template <typename T>
+using ParamCrossover =
+    std::function<T(T param1, T param2, float sol1_relative_perf, std::mt19937 &rng)>;
+
+// helper that turns a VectorCrossover into a SolCrossover
+template <typename ObsType>
+SolCrossover<ObsType> to_sol_crossover(VectorCrossover vec_cross) {
+  return [vec_cross](const Solution<ObsType> &sol1, const Solution<ObsType> &sol2,
+                     std::mt19937 &rng) -> std::shared_ptr<Model<ObsType>> {
+    // check compatibility
+    if (!check_spans_compatible(sol1.model->get_spans(), sol2.model->get_spans())) {
+      // parents aren't compatible, so random pick a parent and return a clone
+      std::uniform_int_distribution<int> dist(0, 1);
+      if (dist(rng) == 0) {
+        return sol1.model->clone();
+      } else {
+        return sol2.model->clone();
+      }
+    }
+    // parents are compatible so move on to the crossover
+    auto child = sol1.model->clone();
+    float sol1_relative_perf = static_cast<float>(sol1.fitness) / (sol1.fitness + sol2.fitness);
+    vec_cross(sol1.model->get_spans(), sol2.model->get_spans(), child->get_spans(),
+              sol1_relative_perf, rng);
+    // apply child crossover
+    child->apply_spans();
+    return child;
+  };
+}
+
+// helper that turns a SpanCrossover into a VectorCrossover
+VectorCrossover to_vec_crossover(SpanCrossover span_cross) {
+  return [span_cross](const std::vector<ParamSpan> &spans1, const std::vector<ParamSpan> &spans2,
+                      std::vector<ParamSpan> &child_spans, float sol1_relative_perf,
+                      std::mt19937 &rng) {
+    // apply the span crossover to each span pair
+    for (size_t i = 0; i < spans1.size(); ++i) {
+      span_cross(spans1[i], spans2[i], child_spans[i], sol1_relative_perf, rng);
+    }
+  };
+}
+
+// helper that turns a ParamCrossover into a SpanCrossover
+template <typename F>
+SpanCrossover to_span_crossover(F param_cross) {
+  return [param_cross](const ParamSpan &span1, const ParamSpan &span2, ParamSpan &child_span,
+                       float sol1_relative_perf, std::mt19937 &rng) {
+    // use std::visit to apply the parameter strategy to any span type
+    std::visit(
+        [&param_cross, &rng, &sol1_relative_perf](auto &&s1, auto &&s2, auto &&sc) {
+          // using SpanType = std::decay_t<decltype(s1)>;
+          // using ValueType = typename SpanType::value_type;
+          for (size_t j = 0; j < s1.size(); ++j) {
+            sc[j] = param_cross(s1[j], s2[j], sol1_relative_perf, rng);
+          }
+        },
+        span1, span2, child_span);
+  };
+}
+
+template <typename ObsType>
+bool check_spans_compatible(const std::vector<ParamSpan> &spans1,
+                            const std::vector<ParamSpan> &spans2) {
+  // check if number of spans is equal
+  if (spans1.size() != spans2.size()) {
+    return false;
+  }
+
+  // check compatibility of each span
+  // TODO: use C++23 and use https://en.cppreference.com/w/cpp/ranges/zip_view
+  for (size_t i = 0; i < spans1.size(); ++i) {
+    const ParamSpan &span1 = spans1[i];
+    const ParamSpan &span2 = spans2[i];
+
+    // check type compatibility
+    if (span1.index() != span2.index()) {
+      return false;
+    }
+
+    // check length compatibility
+    bool same_size =
+        std::visit([](const auto &s1, const auto &s2) -> bool { return s1.size() == s2.size(); },
+                   span1, span2);
+
+    if (!same_size) {
+      return false;
+    }
+  }
+
+  // everything above matched, so they are compatible.
+  return true;
+}
+
+} // namespace ga

--- a/software/src/optimizers/ga.h
+++ b/software/src/optimizers/ga.h
@@ -6,9 +6,12 @@
 
 #include "model.h"
 
-using model::Model;
-
 namespace ga {
+
+// wrapping in anonymous namespace makes usage private to this file.
+namespace {
+using model::Model;
+}
 
 // a struct to keep track of various fitness values associated with a model
 template <typename ObsType>

--- a/software/src/optimizers/ga_funs.h
+++ b/software/src/optimizers/ga_funs.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <vector>
 
+#include "crossover_types.h"
 #include "ga.h"
 #include "game.h"
 #include "model.h"
@@ -39,6 +40,34 @@ Populate<ObsType> make_tournament(size_t size) {
     for (size_t i = 0; i < current.size(); ++i) {
       // run a tournament and store the winner
       next.emplace_back(tournament_select_single(current, size, rng));
+    }
+  };
+}
+
+template <typename ObsType>
+Populate<ObsType> make_tournament_with_crossover(size_t tournament_size,
+                                                 SolCrossover<ObsType> crossover,
+                                                 float crossover_p) {
+  assert(crossover_p >= 0);
+  return [=](const Population<ObsType> &current, Population<ObsType> &next, std::mt19937 &rng) {
+    next.clear();
+    // determine how many to produce from crossover vs just copying
+    size_t crossover_count = static_cast<size_t>(crossover_p * current.size());
+    size_t non_crossover_count = current.size() - crossover_count;
+
+    // populate with crossover solutions
+    for (size_t i = 0; i < crossover_count; ++i) {
+      // grab two parents and perform crossover
+      auto parent1 = tournament_select_single(current, tournament_size, rng);
+      auto parent2 = tournament_select_single(current, tournament_size, rng);
+      auto child = crossover(parent1, parent2, rng);
+      // child is a model, not a solution, so we need to wrap it
+      next.emplace_back(Solution<ObsType>{child, 0, 0, 0});
+    }
+
+    // populate with non-crossover solutions
+    for (size_t i = 0; i < non_crossover_count; ++i) {
+      next.emplace_back(tournament_select_single(current, tournament_size, rng));
     }
   };
 }

--- a/software/src/optimizers/ga_funs.h
+++ b/software/src/optimizers/ga_funs.h
@@ -6,11 +6,16 @@
 
 #include "ga.h"
 #include "game.h"
+#include "model.h"
 #include "play.h"
 
 namespace ga {
 
-// TODO: this can be private
+// file-private declarations
+namespace {
+
+using model::ParamSpan;
+
 template <typename ObsType>
 Solution<ObsType> tournament_select_single(const Population<ObsType> &evaled_pop,
                                            size_t tournament_size, std::mt19937 &rng) {
@@ -24,6 +29,8 @@ Solution<ObsType> tournament_select_single(const Population<ObsType> &evaled_pop
   }
   return evaled_pop[best_idx];
 }
+
+} // namespace
 
 template <typename ObsType>
 Populate<ObsType> make_tournament(size_t size) {

--- a/software/src/optimizers/simple.h
+++ b/software/src/optimizers/simple.h
@@ -1,3 +1,5 @@
+// TODO: this is legacy code that is now only used for pl configuration. it should be refactored to
+// reflect that.
 #pragma once
 
 #include <functional>

--- a/software/src/training.cpp
+++ b/software/src/training.cpp
@@ -3,6 +3,8 @@
 #include "games/jnb.h"
 #include "models/mlp_simple.h"
 #include "observation_types.h"
+#include "optimizers/crossover_funs.h"
+#include "optimizers/crossover_types.h"
 #include "optimizers/ga_funs.h"
 
 #include <random>
@@ -34,4 +36,73 @@ void train(const std::string &map_filename) {
   State<obs::Simple> state;
   init(state, config);
   run(state, config);
+}
+
+void train_crossover_example(const std::string &map_filename) {
+  // define the game that the agents are to play in.
+  // this hooks into the fitness function.
+  jnb::JnBGame game(map_filename, 400); // framelimit set to 400
+
+  // the models need to know the shape of the game's observation,
+  // so we build one and pass it to the model initialization.
+  auto sample_obs = game.build_observation();
+
+  // the ga config need a function that tells it how to create the
+  // initial population. this is a function that takes in rng and returns
+  // a shared_ptr to a model. in this build function, we construct the
+  // SimpleMLP model, initialize it with the sample observation and game
+  // action count, then return it.
+  ModelBuilder<obs::Simple> build_model =
+      [&](std::mt19937 &rng) -> std::shared_ptr<model::Model<obs::Simple>> {
+    auto new_model = std::make_shared<model::SimpleMLP>(32, 3);
+    new_model->init(sample_obs[0], game.get_action_count(), rng);
+    return new_model;
+  };
+
+  // now we can populate the GA config
+  Config<obs::Simple> config;
+  config.model_builder = build_model;
+  // i have prior best turned off in this example, but this can't be null so i set it
+  config.prior_best_select = best_prior_best<obs::Simple>;
+  config.prior_best_size = 0;
+  config.mutation_rate = 0.001f;
+  // here the game is getting wrapped and turned into a fitness function.
+  // this particular fitness function is for 2 player games and incorporates
+  // the prior best and reference models.
+  config.fitness_fun = make_game_fitness_2p<obs::Simple>(std::make_shared<jnb::JnBGame>(game));
+  // the fitness_logger is called once per generation. the fitness_printer computes
+  // the min, max, and avg fitness per generation and prints it.
+  // however, we could easily make one that writes stats to a file for later analysis.
+  config.fitness_logger = fitness_printer<obs::Simple>;
+  // the crossover function i'm using is a parameter-wise crossover, but the ga expects
+  // solution-wise crossover. i can use the converter functions to turn the param-wise
+  // crossover into a span-wise, then to vector-wise, then to sol-wise.
+  // kinda gross, but this lets us define crossover functions of varying granularity,
+  // then we can just convert them into the least granular type to pass to the ga config.
+  auto sol_uniform_crossover =
+      to_sol_crossover<obs::Simple>(to_vec_crossover(to_span_crossover(uniform_crossover)));
+  // here im passing the solution-wise crossover function to a function that
+  // make a population function using tournament select combined with the crossover.
+  // it takes in the tournament size, the crossover, and the crossover proportion.
+  config.populate_fun = make_tournament_with_crossover(4, sol_uniform_crossover, 0.8f);
+
+  // above i convert an existing crossover function, but we could also define one inline.
+  // here i made a crossover that takes 25% of p1 and 75% of p2, where p1 is a param
+  // from model1, and p2 is the corresponding parameter from model2.
+  auto crossover_25 = [](auto p1, auto p2, float sol1_relative_perf, std::mt19937 &rng) {
+    // 25% p1, 75% p2
+    // TODO: this might break on non-float models
+    return (p1 / 4) + (3 * p2/4);
+  };
+  // i still need to convert this:
+  auto sol_crossover_25 =
+      to_sol_crossover<obs::Simple>(to_vec_crossover(to_span_crossover(crossover_25)));
+  // and if i were to use this, i would hook it in here:
+  // config.populate_fun = make_tournament_with_crossover(4, sol_crossover_25, 0.8f);
+
+  // now i just need to make the ga state, init it, and run it
+  State<obs::Simple> state;
+  init(state, config);
+  run(state, config);
+  // should be training now
 }

--- a/software/src/training.h
+++ b/software/src/training.h
@@ -5,3 +5,5 @@
 using namespace ga;
 
 void train(const std::string &map_filename);
+
+void train_crossover_example(const std::string &map_filename);


### PR DESCRIPTION
Adds crossover support to the ga. The key idea is to add a get_spans function to the model interface. A span is just a non-owning view into a contiguous array. get_spans returns a vector of spans that point to the trainable parameters. This allows us to decouple the crossover functions from particular models, because they can operate on vectors of spans instead. Take a look at train_crossover_example from training.cpp to see an example of configuring a GA with crossover. This example uses parameter-wise crossover functions, but you can also make crossover functions that operate on spans, vectors of spans, or entire solutions if necessary. 